### PR TITLE
Modernize Python benchmark code and extend to Cassandra and Astra DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ online_store.db
 registry.db
 venv
 requests*.json
+*.secrets
+secure-connect*.zip

--- a/python/README.md
+++ b/python/README.md
@@ -16,6 +16,8 @@ You need to have the following installed:
 
 All these benchmarks are run on an EC2 instance (c5.4xlarge, 16vCPU, 32GiB memory) or a GCP GCE instance (c2-standard-16, 16 vCPU, 64GiB memory), on the same region as the target online stores.
 
+**Note**: see [here](cloud_machines.md) for details on how to provision the cloud instances to run the tests.
+
 ## Generate Data
 
 For all of the following benchmarks, you'll need to generate the data using `data_generator.py` under the top-level directory of this repo. Just `cd` to the main directory and run `python data_generator.py`.
@@ -270,6 +272,12 @@ Creating datastore_feast_14 ... done
 Creating datastore_feast_15 ... done
 Creating datastore_feast_16 ... done
 ```
+
+> _Note_: The Python google package requires not only the credentials to be accessible
+> (in read-write mode, as can be seen in the Datastore docker-compose.yml),
+> but also the google cloud SDK to be installed.
+> For this reason there is an additional step in the Dockerfile for Datastore,
+> which handles the installation. [Reference](https://stackoverflow.com/questions/28372328/how-to-install-the-google-cloud-sdk-in-a-docker-image).
 
 3. Materialize data to Datastore
 

--- a/python/README.md
+++ b/python/README.md
@@ -10,7 +10,7 @@ You need to have the following installed:
 * Docker Compose
 * Vegeta
 
-All these benchmarks are run on an EC2 instance (c5.4xlarge, 16vCPU, 64GiB memory).
+All these benchmarks are run on an EC2 instance (c5.4xlarge, 16vCPU, 64GiB memory) or a GCP GCE instance (c2-standard-16, 16 vCPU), on the same region as the target online stores.
 
 ## Generate Data
 

--- a/python/README.md
+++ b/python/README.md
@@ -23,17 +23,20 @@ For all of the following benchmarks, you'll need to generate the data using `dat
 ## Redis
 
 1. Apply feature definitions to create a Feast repo.
+
 ```
 cd python/feature_repos/redis
 feast apply
 ```
 
 2. Deploy Redis & feature servers using docker-compose
+
 ```
 cd ../../docker/redis
 docker-compose up -d
 ```
 If everything goes well, you should see an output like this:
+
 ```
 Creating redis_redis_1 ... done
 Creating redis_feast_1  ... done
@@ -55,6 +58,7 @@ Creating redis_feast_16 ... done
 ```
 
 3. Materialize data to Redis
+
 ```
 cd ../../feature_repos/redis
 # This is unfortunately necessary because inside docker feature servers resolve
@@ -68,11 +72,13 @@ sed -i 's/localhost:6379/redis:6379/g' feature_store.yaml
 ```
 
 4. Check that feature servers are working & they have materialized data
+
 ```
 cd ../../..
 parquet-tools show --columns entity generated_data.parquet 2>/dev/null | head -n 6
 ```
 This should return something like this:
+
 ```
 +----------+
 |   entity |
@@ -83,6 +89,7 @@ This should return something like this:
 ```
 
 Put these numbers into an env variable with:
+
 ```
 TEST_ENTITY_IDS=`parquet-tools show --columns entity generated_data.parquet 2>/dev/null | head -n 6 | tail -n 3 | sed 's/|//g' | paste -d, -s`
 echo $TEST_ENTITY_IDS
@@ -91,6 +98,7 @@ echo $TEST_ENTITY_IDS
 
 
 Query the feature server with
+
 ```
 curl -X POST \
   "http://127.0.0.1:6566/get-online-features" \
@@ -106,6 +114,7 @@ curl -X POST \
 
 In the output, make sure that `"values"` field contains none of the null
 values. It should look something like this:
+
 ```
     {
       "values": [
@@ -115,6 +124,7 @@ values. It should look something like this:
 ```
 
 5. Run Benchmarks
+
 ```
 cd python
 ./run-benchmark.sh
@@ -125,17 +135,20 @@ cd python
 For this benchmark, you'll need to have AWS credentials configured in `~/.aws/credentials`.
 
 1. Apply feature definitions to create a Feast repo.
+
 ```
 cd feature_repos/dynamo
 feast apply
 ```
 
 2. Deploy feature servers using docker-compose
+
 ```
 cd ../../docker/dynamo
 docker-compose up -d
 ```
 If everything goes well, you should see an output like this:
+
 ```
 Creating dynamo_feast_1  ... done
 Creating dynamo_feast_2  ... done
@@ -156,17 +169,20 @@ Creating dynamo_feast_16 ... done
 ```
 
 3. Materialize data to DynamoDB
+
 ```
 cd ../../feature_repos/dynamo
 feast materialize-incremental $(date -u +"%Y-%m-%dT%H:%M:%S")
 ```
 
 4. Check that feature servers are working & they have materialized data
+
 ```
 cd ../../..
 parquet-tools show --columns entity generated_data.parquet 2>/dev/null | head -n 6
 ```
 This should return something like this:
+
 ```
 +----------+
 |   entity |
@@ -177,14 +193,15 @@ This should return something like this:
 ```
 
 Put these numbers into an env variable with:
+
 ```
 TEST_ENTITY_IDS=`parquet-tools show --columns entity generated_data.parquet 2>/dev/null | head -n 6 | tail -n 3 | sed 's/|//g' | paste -d, -s`
 echo $TEST_ENTITY_IDS
 ```
 (which should output something like `94  ,   1992   ,   4475  `)
 
-
 Query the feature server with
+
 ```
 curl -X POST \
   "http://127.0.0.1:6566/get-online-features" \
@@ -198,6 +215,7 @@ curl -X POST \
 ```
 
 In the output, make sure that `"values"` field contains none of the null values. It should look something like this:
+
 ```
     {
       "values": [
@@ -207,6 +225,7 @@ In the output, make sure that `"values"` field contains none of the null values.
 ```
 
 5. Run Benchmarks
+
 ```
 cd python
 ./run-benchmark.sh
@@ -219,17 +238,20 @@ For this benchmark, you need GCP credentials accessible. Here it is assumed that
 the feature server. (Adjust as needed by inspecting the `docker-compose.yml`).
 
 1. Apply feature definitions to create a Feast repo.
+
 ```
 cd feature_repos/datastore
 feast apply
 ```
 
 2. Deploy feature servers using docker-compose
+
 ```
 cd ../../docker/datastore
 docker-compose up -d
 ```
 If everything goes well, you should see an output like this:
+
 ```
 Creating datastore_feast_1  ... done
 Creating datastore_feast_2  ... done
@@ -250,17 +272,20 @@ Creating datastore_feast_16 ... done
 ```
 
 3. Materialize data to Datastore
+
 ```
 cd ../../feature_repos/datastore
 feast materialize-incremental $(date -u +"%Y-%m-%dT%H:%M:%S")
 ```
 
 4. Check that feature servers are working & they have materialized data
+
 ```
 cd ../../..
 parquet-tools show --columns entity generated_data.parquet 2>/dev/null | head -n 6
 ```
 This should return something like this:
+
 ```
 +----------+
 |   entity |
@@ -271,6 +296,7 @@ This should return something like this:
 ```
 
 Put these numbers into an env variable with:
+
 ```
 TEST_ENTITY_IDS=`parquet-tools show --columns entity generated_data.parquet 2>/dev/null | head -n 6 | tail -n 3 | sed 's/|//g' | paste -d, -s`
 echo $TEST_ENTITY_IDS
@@ -279,6 +305,7 @@ echo $TEST_ENTITY_IDS
 
 
 Query the feature server with
+
 ```
 curl -X POST \
   "http://127.0.0.1:6566/get-online-features" \
@@ -292,6 +319,7 @@ curl -X POST \
 ```
 
 In the output, make sure that `"values"` field contains none of the null values. It should look something like this:
+
 ```
     {
       "values": [
@@ -301,6 +329,246 @@ In the output, make sure that `"values"` field contains none of the null values.
 ```
 
 5. Run Benchmarks
+
+```
+cd python
+./run-benchmark.sh
+```
+
+
+## Cassandra
+
+This runs on a single-node Cassandra cluster running in Docker alongside the
+benchmarking containers.
+
+1. Start the docker containers:
+
+```
+cd docker/cassandra
+docker compose up
+```
+
+If everything goes well, you should see an output like this:
+
+```
+ ⠿ Network cassandra_default        Created       0.0s
+ ⠿ Container cassandra-cassandra-1  Started       0.6s
+ ⠿ Container cassandra-feast-16     Started       1.0s
+ ⠿ Container cassandra-feast-1      Started       1.5s
+ ⠿ Container cassandra-feast-8      Started       3.0s
+ ⠿ Container cassandra-feast-4      Started       2.4s
+ ⠿ Container cassandra-feast-2      Started       2.4s
+ ⠿ Container cassandra-feast-14     Started       2.2s
+ ⠿ Container cassandra-feast-5      Started       1.5s
+ ⠿ Container cassandra-feast-3      Started       2.8s
+ ⠿ Container cassandra-feast-13     Started       0.8s
+ ⠿ Container cassandra-feast-9      Started       1.3s
+ ⠿ Container cassandra-feast-11     Started       1.7s
+ ⠿ Container cassandra-feast-15     Started       0.9s
+ ⠿ Container cassandra-feast-6      Started       2.8s
+ ⠿ Container cassandra-feast-12     Started       2.0s
+ ⠿ Container cassandra-feast-7      Started       2.5s
+ ⠿ Container cassandra-feast-10     Started       1.8s
+```
+
+Wait about 60-90 seconds for Cassandra to fully start. Then you can proceed (if not ready yet, the next command will error and you can retry it a little later).
+
+2. Create the destination keyspace in Cassandra: check the output of this command to make sure `feast_test` is no where.
+
+```
+docker exec -it cassandra-cassandra-1 cqlsh -e \
+  "CREATE KEYSPACE feast_test WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1}; DESC KEYSPACES;"
+
+```
+
+3. From the host machine, provision the feature store:
+
+```
+# This is unfortunately necessary because inside docker feature servers resolve
+# Cassandra host name as `cassandra`, but since we're running materialization from shell,
+# Cassandra is accessible on localhost:
+sed -i 's/- cassandra/- localhost/g' feature_store.yaml
+feast apply
+# Make sure to change this back, since it can mess up with feature servers
+# if you run another docker-compose command later:
+sed -i 's/- localhost/- cassandra/g' feature_store.yaml
+```
+
+4. Similarly, materialize from the host machine:
+
+```
+# This is unfortunately necessary because inside docker feature servers resolve
+# Cassandra host name as `cassandra`, but since we're running materialization from shell,
+# Cassandra is accessible on localhost:
+sed -i 's/- cassandra/- localhost/g' feature_store.yaml
+feast materialize-incremental $(date -u +"%Y-%m-%dT%H:%M:%S")
+# Make sure to change this back, since it can mess up with feature servers
+# if you run another docker-compose command later:
+sed -i 's/- localhost/- cassandra/g' feature_store.yaml
+```
+
+5. Check that feature servers are working & they have materialized data
+
+```
+cd ../../..
+parquet-tools show --columns entity generated_data.parquet 2>/dev/null | head -n 6
+```
+This should return something like this:
+
+```
++----------+
+|   entity |
+|----------|
+|       94 |
+|     1992 |
+|     4475 |
+```
+
+Put these numbers into an env variable with:
+
+```
+TEST_ENTITY_IDS=`parquet-tools show --columns entity generated_data.parquet 2>/dev/null | head -n 6 | tail -n 3 | sed 's/|//g' | paste -d, -s`
+echo $TEST_ENTITY_IDS
+```
+(which should output something like `94  ,   1992   ,   4475  `)
+
+
+Query the feature server with
+
+```
+curl -X POST \
+  "http://127.0.0.1:6566/get-online-features" \
+  -H "accept: application/json" \
+  -d "{
+    \"feature_service\": \"feature_service_0\",
+    \"entities\": {
+      \"entity\": [$TEST_ENTITY_IDS]
+    }
+  }" | jq
+```
+
+In the output, make sure that `"values"` field contains none of the null values. It should look something like this:
+
+```
+    {
+      "values": [
+        4475,
+        1551,
+        9889,        
+```
+
+6. Run Benchmarks
+
+```
+cd python
+./run-benchmark.sh
+```
+
+
+## Astra DB
+
+Ensure you have an Astra DB instance in the same AWS region as your benchmarking
+client. To connect to it you need the Client ID and the Client Secret from a
+database token, as well as the "secure connect bundle" zip-file which should
+be placed inside the `python/feature_repos/astra_db/` directory.
+
+Adjust file `feature_store.yaml` in that directory to reflect Client ID, Client
+Secret, database keyspace name, AWS region name and secure-connect-bundle filename.
+
+1. Apply feature definitions to create a Feast repo.
+
+```
+cd feature_repos/astra_db
+feast apply
+```
+
+2. Deploy feature servers using docker-compose
+
+```
+cd ../../docker/astra_db
+docker-compose up -d
+```
+If everything goes well, you should see an output like this:
+
+```
+ ⠿ Network astra_db_default     Created        0.0s
+ ⠿ Container astra_db-feast-1   Started        2.7s
+ ⠿ Container astra_db-feast-16  Started        2.8s
+ ⠿ Container astra_db-feast-3   Started        2.4s
+ ⠿ Container astra_db-feast-5   Started        1.4s
+ ⠿ Container astra_db-feast-11  Started        1.8s
+ ⠿ Container astra_db-feast-4   Started        1.6s
+ ⠿ Container astra_db-feast-2   Started        1.2s
+ ⠿ Container astra_db-feast-6   Started        0.8s
+ ⠿ Container astra_db-feast-12  Started        2.1s
+ ⠿ Container astra_db-feast-7   Started        3.0s
+ ⠿ Container astra_db-feast-8   Started        0.8s
+ ⠿ Container astra_db-feast-10  Started        2.8s
+ ⠿ Container astra_db-feast-14  Started        1.2s
+ ⠿ Container astra_db-feast-15  Started        2.9s
+ ⠿ Container astra_db-feast-13  Started        1.8s
+ ⠿ Container astra_db-feast-9   Started        2.3s
+```
+
+3. Materialize data to Astra DB
+
+```
+cd ../../feature_repos/astra_db
+feast materialize-incremental $(date -u +"%Y-%m-%dT%H:%M:%S")
+```
+
+4. Check that feature servers are working & they have materialized data
+
+```
+cd ../../..
+parquet-tools show --columns entity generated_data.parquet 2>/dev/null | head -n 6
+```
+This should return something like this:
+
+```
++----------+
+|   entity |
+|----------|
+|       94 |
+|     1992 |
+|     4475 |
+```
+
+Put these numbers into an env variable with:
+
+```
+TEST_ENTITY_IDS=`parquet-tools show --columns entity generated_data.parquet 2>/dev/null | head -n 6 | tail -n 3 | sed 's/|//g' | paste -d, -s`
+echo $TEST_ENTITY_IDS
+```
+(which should output something like `94  ,   1992   ,   4475  `)
+
+
+Query the feature server with
+
+```
+curl -X POST \
+  "http://127.0.0.1:6566/get-online-features" \
+  -H "accept: application/json" \
+  -d "{
+    \"feature_service\": \"feature_service_0\",
+    \"entities\": {
+      \"entity\": [$TEST_ENTITY_IDS]
+    }
+  }" | jq
+```
+
+In the output, make sure that `"values"` field contains none of the null values. It should look something like this:
+
+```
+    {
+      "values": [
+        4475,
+        1551,
+        9889,        
+```
+
+5. Run Benchmarks
+
 ```
 cd python
 ./run-benchmark.sh

--- a/python/README.md
+++ b/python/README.md
@@ -373,7 +373,7 @@ If everything goes well, you should see an output like this:
 
 Wait about 60-90 seconds for Cassandra to fully start. Then you can proceed (if not ready yet, the next command will error and you can retry it a little later).
 
-2. Create the destination keyspace in Cassandra: check the output of this command to make sure `feast_test` is no where.
+2. Create the destination keyspace in Cassandra: check the output of this command to make sure `feast_test` is now here.
 
 ```
 docker exec -it cassandra-cassandra-1 cqlsh -e \
@@ -396,6 +396,7 @@ feast apply
 sed -i 's/- localhost/- cassandra/g' feature_store.yaml
 ```
 
+
 4. Similarly, materialize from the host machine:
 
 ```
@@ -407,6 +408,37 @@ feast materialize-incremental $(date -u +"%Y-%m-%dT%H:%M:%S")
 # Make sure to change this back, since it can mess up with feature servers
 # if you run another docker-compose command later:
 sed -i 's/- localhost/- cassandra/g' feature_store.yaml
+```
+
+3b. A workaround for the Dockerized feast to work
+
+The Docker container have a _copy_ of the registry directory, including data/registry.db.
+But the image gets done before the `apply` step above (it is inevitable if we want
+to create the keyspace and have the Cassandra part of the `docker-compose`),
+so the Docker `feast`s have not the updated `registry.db`. For the time being, a workaround
+is as follows:
+
+```
+docker cp data/registry.db cassandra-feast-1:/feature_repo/data/registry.db
+docker cp data/registry.db cassandra-feast-2:/feature_repo/data/registry.db
+docker cp data/registry.db cassandra-feast-3:/feature_repo/data/registry.db
+docker cp data/registry.db cassandra-feast-4:/feature_repo/data/registry.db
+docker cp data/registry.db cassandra-feast-5:/feature_repo/data/registry.db
+docker cp data/registry.db cassandra-feast-6:/feature_repo/data/registry.db
+docker cp data/registry.db cassandra-feast-7:/feature_repo/data/registry.db
+docker cp data/registry.db cassandra-feast-8:/feature_repo/data/registry.db
+docker cp data/registry.db cassandra-feast-9:/feature_repo/data/registry.db
+docker cp data/registry.db cassandra-feast-10:/feature_repo/data/registry.db
+docker cp data/registry.db cassandra-feast-11:/feature_repo/data/registry.db
+docker cp data/registry.db cassandra-feast-12:/feature_repo/data/registry.db
+docker cp data/registry.db cassandra-feast-13:/feature_repo/data/registry.db
+docker cp data/registry.db cassandra-feast-14:/feature_repo/data/registry.db
+docker cp data/registry.db cassandra-feast-15:/feature_repo/data/registry.db
+docker cp data/registry.db cassandra-feast-16:/feature_repo/data/registry.db
+
+cd ../../docker/cassandra/
+docker-compose restart
+cd ../../feature_repos/cassandra/
 ```
 
 5. Check that feature servers are working & they have materialized data
@@ -476,6 +508,12 @@ be placed inside the `python/feature_repos/astra_db/` directory.
 
 Adjust file `feature_store.yaml` in that directory to reflect Client ID, Client
 Secret, database keyspace name, AWS region name and secure-connect-bundle filename.
+
+**Note**: in order to be able to share the same `feature_store.yaml` from both
+the Dockerized `feast` instances and the one on the host machine,
+please put the secure connect bundle in the `python/feature_repos/astra_db/`
+directory itself and refer to it as `./secure-connect-DATABASENAME.zip`
+(i.e. with a relative path).
 
 1. Apply feature definitions to create a Feast repo.
 

--- a/python/README.md
+++ b/python/README.md
@@ -174,6 +174,7 @@ This should return something like this:
 |       94 |
 |     1992 |
 |     4475 |
+```
 
 Put these numbers into an env variable with:
 ```
@@ -267,6 +268,7 @@ This should return something like this:
 |       94 |
 |     1992 |
 |     4475 |
+```
 
 Put these numbers into an env variable with:
 ```

--- a/python/README.md
+++ b/python/README.md
@@ -345,7 +345,7 @@ benchmarking containers.
 
 ```
 cd docker/cassandra
-docker compose up
+docker-compose up -d
 ```
 
 If everything goes well, you should see an output like this:
@@ -384,6 +384,8 @@ docker exec -it cassandra-cassandra-1 cqlsh -e \
 3. From the host machine, provision the feature store:
 
 ```
+cd ../../feature_repos/cassandra/
+
 # This is unfortunately necessary because inside docker feature servers resolve
 # Cassandra host name as `cassandra`, but since we're running materialization from shell,
 # Cassandra is accessible on localhost:

--- a/python/cloud_machines.md
+++ b/python/cloud_machines.md
@@ -1,0 +1,154 @@
+# Provisioning the cloud machines
+
+This is by far not the only possible setup, but it is a possible way to
+get a working cloud setup to run the tests. No automation is involved here
+at the moment: it is just a bunch of commands to run on the instances,
+aimed at having Python and all other tools installed and available.
+
+## AWS
+
+It is assumed the following AMI has been used to create the machine:
+`Amazon Linux 2 Kernel 5.10 AMI 2.0.20220912.1 x86_64 HVM gp2`.
+
+### General setup
+
+The following and installs: git, Vegeta, docker/docker-compose and jq; and clones this repo:
+([partial inspiration](https://www.cyberciti.biz/faq/how-to-install-docker-on-amazon-linux-2/))
+
+```
+sudo yum update -y
+
+sudo yum install git -y
+git clone https://github.com/feast-dev/feast-benchmarks.git
+
+mkdir bin
+curl -L -O https://github.com/tsenart/vegeta/releases/download/v12.8.4/vegeta_12.8.4_linux_386.tar.gz
+mv vegeta_12.8.4_linux_386.tar.gz bin
+tar -xvf bin/vegeta_12.8.4_linux_386.tar.gz -C bin
+
+sudo yum install docker -y
+sudo usermod -a -G docker ec2-user
+id ec2-user
+newgrp docker
+
+wget https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)
+sudo mv docker-compose-$(uname -s)-$(uname -m) /usr/local/bin/docker-compose
+sudo chmod -v +x /usr/local/bin/docker-compose
+
+sudo systemctl enable docker.service
+sudo systemctl start docker.service
+
+sudo yum install jq -y
+```
+
+### Python
+
+The following enables and installs (in a virtualenv) Python 3.8, required by modern Feast,
+since the machine by defaults ships with 3.7 only; and installs Feast and parquet-tools.
+
+```
+sudo yum install -y amazon-linux-extras
+sudo amazon-linux-extras enable python3.8
+sudo yum install python3.8 -y
+
+pip3 install virtualenv
+virtualenv -p /usr/bin/python3.8 feast38
+. feast38/bin/activate
+
+pip install "feast[redis,aws,cassandra]==0.26"
+pip install parquet-tools
+```
+
+### AWS credentials
+
+You probably want to copy your `~/.aws` folder over to the machine:
+
+```
+rsync -ravstp -e 'ssh -i keypair-used-for-aws.pem' $HOME/.aws ec2-user@$TARGET_IP:/home/ec2-user/
+```
+
+## GCP
+
+It is assumed the machine has been created with the `Debian 10 marketplace image`.
+
+You can use the GCP "Web console" to log on to the machine and inject your
+ssh key to the `~/.ssh/authorized_keys` file on it.
+Beware: there is a daemon script that periodically resets the file, so that
+new connections might not work. Quick and dirty way: repeat this Web-console-based
+injection. Proper way: see [here](https://cloud.google.com/compute/docs/instances/access-overview)
+on how to use the machine metadata and have the daemon
+provide your key to the authorized hosts.
+
+For the following you should be logged on to the machine.
+
+### General setup
+
+The following and installs: git, Vegeta, docker/docker-compose, jq and rsync; and clones this repo:
+([partial inspiration](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-on-debian-10))
+
+```
+sudo apt update
+sudo apt install git -y
+
+git clone https://github.com/feast-dev/feast-benchmarks.git
+
+mkdir bin
+curl -L -O https://github.com/tsenart/vegeta/releases/download/v12.8.4/vegeta_12.8.4_linux_386.tar.gz
+mv vegeta_12.8.4_linux_386.tar.gz bin
+tar -xvf bin/vegeta_12.8.4_linux_386.tar.gz -C bin
+export PATH="$PATH:$HOME/bin"
+
+sudo apt install apt-transport-https ca-certificates curl gnupg2 software-properties-common
+curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
+sudo apt update
+apt-cache policy docker-ce
+sudo apt install docker-ce -y
+sudo usermod -a -G docker `whoami`
+id `whoami`
+newgrp docker
+
+sudo apt install wget -y
+wget https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)
+sudo mv docker-compose-$(uname -s)-$(uname -m) /usr/local/bin/docker-compose
+sudo chmod -v +x /usr/local/bin/docker-compose
+
+sudo systemctl enable docker.service
+sudo systemctl start docker.service
+
+sudo apt install jq -y
+sudo apt install rsync -y
+```
+
+### Python
+
+Python 3.8 must be built from source `¯\_(ツ)_/¯`:
+
+```
+sudo apt update
+sudo apt install build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev curl libbz2-dev -y
+curl -O https://www.python.org/ftp/python/3.8.2/Python-3.8.2.tar.xz
+tar -xf Python-3.8.2.tar.xz
+cd Python-3.8.2
+./configure --enable-optimizations
+make -j 4
+sudo make altinstall
+
+sudo apt install python3-pip -y
+
+pip3 install virtualenv
+python3.7 -m virtualenv -p /usr/local/bin/python3.8 feast38
+. feast38/bin/activate
+
+pip install "feast[gcp]>=0.25"
+pip install parquet-tools
+```
+
+### GCP credentials
+
+Assuming your local computer is set up for GCP access and
+your credentials are stored in the directory below:
+
+```
+rsync -ravstp $HOME/.config/gcloud USERNAME@TARGET_IP:/home/USERNAME/.config
+```

--- a/python/docker/astra_db/Dockerfile
+++ b/python/docker/astra_db/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.9
+
+RUN pip3 install 'feast[cassandra]==0.25.1'
+
+COPY feature_repos/astra_db feature_repo
+
+WORKDIR feature_repo
+
+ENV FEAST_USAGE=False
+
+CMD feast serve --host "0.0.0.0" --port 6566

--- a/python/docker/astra_db/Dockerfile
+++ b/python/docker/astra_db/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9
 
-RUN pip3 install git+https://github.com/hemidactylus/feast.git@sl-cassandra-optimize-bulk-reads#egg=feast[cassandra]
+RUN pip3 install 'feast[cassandra]==0.26'
 
 COPY feature_repos/astra_db feature_repo
 

--- a/python/docker/astra_db/Dockerfile
+++ b/python/docker/astra_db/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9
 
-RUN pip3 install 'feast[cassandra]==0.26'
+RUN pip3 install git+https://github.com/hemidactylus/feast.git@sl-cassandra-optimize-bulk-reads#egg=feast[cassandra]
 
 COPY feature_repos/astra_db feature_repo
 

--- a/python/docker/astra_db/Dockerfile
+++ b/python/docker/astra_db/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9
 
-RUN pip3 install 'feast[cassandra]==0.25.1'
+RUN pip3 install 'feast[cassandra]==0.26'
 
 COPY feature_repos/astra_db feature_repo
 

--- a/python/docker/astra_db/docker-compose.yml
+++ b/python/docker/astra_db/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  feast:
+    build:
+      context: ../..
+      dockerfile: docker/astra_db/Dockerfile
+    ports:
+      - "6566-6581:6566"
+    deploy:
+      replicas: 16

--- a/python/docker/cassandra/Dockerfile
+++ b/python/docker/cassandra/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9
 
-RUN pip3 install git+https://github.com/hemidactylus/feast.git@sl-cassandra-optimize-bulk-reads#egg=feast[cassandra]
+RUN pip3 install 'feast[cassandra]==0.26'
 
 COPY feature_repos/cassandra feature_repo
 

--- a/python/docker/cassandra/Dockerfile
+++ b/python/docker/cassandra/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.9
+
+RUN pip3 install 'feast[cassandra]==0.25.1'
+
+COPY feature_repos/cassandra feature_repo
+
+WORKDIR feature_repo
+
+ENV FEAST_USAGE=False
+
+CMD feast serve --host "0.0.0.0" --port 6566

--- a/python/docker/cassandra/Dockerfile
+++ b/python/docker/cassandra/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9
 
-RUN pip3 install 'feast[cassandra]==0.26'
+RUN pip3 install git+https://github.com/hemidactylus/feast.git@sl-cassandra-optimize-bulk-reads#egg=feast[cassandra]
 
 COPY feature_repos/cassandra feature_repo
 

--- a/python/docker/cassandra/Dockerfile
+++ b/python/docker/cassandra/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9
 
-RUN pip3 install 'feast[cassandra]==0.25.1'
+RUN pip3 install 'feast[cassandra]==0.26'
 
 COPY feature_repos/cassandra feature_repo
 

--- a/python/docker/cassandra/docker-compose.yml
+++ b/python/docker/cassandra/docker-compose.yml
@@ -7,3 +7,9 @@ services:
       - "6566-6581:6566"
     deploy:
       replicas: 16
+    links:
+      - cassandra
+  cassandra:
+    image: cassandra:4.1
+    ports:
+     - "9042:9042"

--- a/python/docker/cassandra/docker-compose.yml
+++ b/python/docker/cassandra/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  feast:
+    build:
+      context: ../..
+      dockerfile: docker/cassandra/Dockerfile
+    ports:
+      - "6566-6581:6566"
+    deploy:
+      replicas: 16

--- a/python/docker/datastore/Dockerfile
+++ b/python/docker/datastore/Dockerfile
@@ -1,5 +1,16 @@
 FROM python:3.9
 
+# Downloading gcloud package
+RUN curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz > /tmp/google-cloud-sdk.tar.gz
+
+# Installing the package
+RUN mkdir -p /usr/local/gcloud \
+  && tar -C /usr/local/gcloud -xvf /tmp/google-cloud-sdk.tar.gz \
+  && /usr/local/gcloud/google-cloud-sdk/install.sh
+
+# Adding the package path to local
+ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
+
 RUN pip3 install 'feast[gcp]==0.25.1'
 
 COPY feature_repos/datastore feature_repo

--- a/python/docker/datastore/Dockerfile
+++ b/python/docker/datastore/Dockerfile
@@ -1,9 +1,6 @@
 FROM python:3.9
 
-RUN pip3 install 'feast[gcp]==0.17.0'
-# Remove after feast 0.18 comes out
-RUN pip3 install 'git+https://github.com/feast-dev/feast.git@9f2c6d6168bac1b11be2c76c6b266a7444fc11c7#subdirectory=sdk/python'
-
+RUN pip3 install 'feast[gcp]==0.25.1'
 
 COPY feature_repos/datastore feature_repo
 

--- a/python/docker/datastore/Dockerfile
+++ b/python/docker/datastore/Dockerfile
@@ -11,7 +11,7 @@ RUN mkdir -p /usr/local/gcloud \
 # Adding the package path to local
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
-RUN pip3 install 'feast[gcp]==0.25.1'
+RUN pip3 install 'feast[gcp]==0.26'
 
 COPY feature_repos/datastore feature_repo
 

--- a/python/docker/datastore/docker-compose.yml
+++ b/python/docker/datastore/docker-compose.yml
@@ -7,3 +7,7 @@ services:
       - "6566-6581:6566"
     deploy:
       replicas: 16
+    volumes:
+      - type: bind
+        source: ${HOME}/.config/gcloud
+        target: /root/.config/gcloud

--- a/python/docker/dynamo/Dockerfile
+++ b/python/docker/dynamo/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9
 
-RUN pip3 install 'feast[aws]==0.25.1'
+RUN pip3 install 'feast[aws]==0.26'
 
 COPY feature_repos/dynamo feature_repo
 

--- a/python/docker/dynamo/Dockerfile
+++ b/python/docker/dynamo/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9
 
-RUN pip3 install 'feast[aws]==0.20.1'
+RUN pip3 install 'feast[aws]==0.25.1'
 
 COPY feature_repos/dynamo feature_repo
 

--- a/python/docker/dynamo/docker-compose.yml
+++ b/python/docker/dynamo/docker-compose.yml
@@ -8,4 +8,7 @@ services:
     deploy:
       replicas: 16
     volumes:
-      - ~/.aws:/root/.aws:ro
+      - type: bind
+        source: ${HOME}/.aws/
+        target: /root/.aws
+        read_only: yes

--- a/python/docker/redis/Dockerfile
+++ b/python/docker/redis/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3.8
+FROM python:3.9
 
-RUN pip3 install 'feast[redis]==0.25.0'
+RUN pip3 install 'feast[redis]==0.25.1'
 RUN pip3 install cffi
 
 COPY feature_repos/redis feature_repo

--- a/python/docker/redis/Dockerfile
+++ b/python/docker/redis/Dockerfile
@@ -1,9 +1,7 @@
 FROM python:3.8
 
-RUN pip3 install 'feast[redis]==0.21.2'
+RUN pip3 install 'feast[redis]==0.25.0'
 RUN pip3 install cffi
-# Remove this after 0.22 ships
-RUN pip3 install 'git+https://github.com/tsotnet/feast.git@caa0cf6c28c771efc8d23f70474cced43a722bb2'
 
 COPY feature_repos/redis feature_repo
 

--- a/python/docker/redis/Dockerfile
+++ b/python/docker/redis/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9
 
-RUN pip3 install 'feast[redis]==0.25.1'
+RUN pip3 install 'feast[redis]==0.26'
 RUN pip3 install cffi
 
 COPY feature_repos/redis feature_repo

--- a/python/feature_repos/astra_db/example.py
+++ b/python/feature_repos/astra_db/example.py
@@ -1,0 +1,45 @@
+import datetime
+
+from feast import Entity, Field, FeatureView, FileSource, FeatureService, ValueType
+from feast.types import Int64
+
+generated_data_source = FileSource(
+    path="../../../generated_data.parquet",
+    event_timestamp_column="event_timestamp",
+)
+
+entity = Entity(
+    name="entity",
+    value_type=ValueType.INT64,
+)
+
+feature_views = [
+    FeatureView(
+        name=f"feature_view_{i}",
+        entities=[entity],
+        ttl=datetime.timedelta(days=1),
+        schema=[
+            Field(name=f"feature_{10 * i + j}", dtype=Int64)
+            for j in range(10)
+        ],
+        online=True,
+        source=generated_data_source,
+    )
+    for i in range(25)
+]
+
+feature_services = [
+    FeatureService(
+        name=f"feature_service_{i}",
+        features=feature_views[:5*(i + 1)],
+    )
+    for i in range(5)
+]
+
+def add_definitions_in_globals():
+    for i, fv in enumerate(feature_views):
+        globals()[f"feature_view_{i}"] = fv
+    for i, fs in enumerate(feature_services):
+        globals()[f"feature_service_{i}"] = fs
+
+add_definitions_in_globals()

--- a/python/feature_repos/astra_db/feature_store.yaml
+++ b/python/feature_repos/astra_db/feature_store.yaml
@@ -1,0 +1,14 @@
+registry: data/registry.db
+project: feature_repo
+provider: local
+online_store:
+  type: cassandra
+  secure_bundle_path: secure-connect-database_name.zip
+  keyspace: feast_test
+  username: token_Client_ID
+  password: token_Client_Secret
+  protocol_version: 4
+  load_balancing:
+    local_dc: 'eu-central-1'
+    load_balancing_policy: 'TokenAwarePolicy(DCAwareRoundRobinPolicy)'
+entity_key_serialization_version: 2

--- a/python/feature_repos/cassandra/example.py
+++ b/python/feature_repos/cassandra/example.py
@@ -1,0 +1,45 @@
+import datetime
+
+from feast import Entity, Field, FeatureView, FileSource, FeatureService, ValueType
+from feast.types import Int64
+
+generated_data_source = FileSource(
+    path="../../../generated_data.parquet",
+    event_timestamp_column="event_timestamp",
+)
+
+entity = Entity(
+    name="entity",
+    value_type=ValueType.INT64,
+)
+
+feature_views = [
+    FeatureView(
+        name=f"feature_view_{i}",
+        entities=[entity],
+        ttl=datetime.timedelta(days=1),
+        schema=[
+            Field(name=f"feature_{10 * i + j}", dtype=Int64)
+            for j in range(10)
+        ],
+        online=True,
+        source=generated_data_source,
+    )
+    for i in range(25)
+]
+
+feature_services = [
+    FeatureService(
+        name=f"feature_service_{i}",
+        features=feature_views[:5*(i + 1)],
+    )
+    for i in range(5)
+]
+
+def add_definitions_in_globals():
+    for i, fv in enumerate(feature_views):
+        globals()[f"feature_view_{i}"] = fv
+    for i, fs in enumerate(feature_services):
+        globals()[f"feature_service_{i}"] = fs
+
+add_definitions_in_globals()

--- a/python/feature_repos/cassandra/feature_store.yaml
+++ b/python/feature_repos/cassandra/feature_store.yaml
@@ -4,7 +4,7 @@ provider: local
 online_store:
   type: cassandra
   hosts:
-    - 172.19.0.18
+    - 127.0.0.1
   keyspace: feast_test
   protocol_version: 5
 entity_key_serialization_version: 2

--- a/python/feature_repos/cassandra/feature_store.yaml
+++ b/python/feature_repos/cassandra/feature_store.yaml
@@ -1,0 +1,10 @@
+registry: data/registry.db
+project: feature_repo
+provider: local
+online_store:
+  type: cassandra
+  hosts:
+    - 172.19.0.18
+  keyspace: feast_test
+  protocol_version: 5
+entity_key_serialization_version: 2

--- a/python/feature_repos/cassandra/feature_store.yaml
+++ b/python/feature_repos/cassandra/feature_store.yaml
@@ -4,7 +4,10 @@ provider: local
 online_store:
   type: cassandra
   hosts:
-    - 127.0.0.1
+    - cassandra
   keyspace: feast_test
   protocol_version: 5
+  load_balancing:
+    local_dc: 'datacenter1'
+    load_balancing_policy: 'TokenAwarePolicy(DCAwareRoundRobinPolicy)'
 entity_key_serialization_version: 2

--- a/python/feature_repos/datastore/example.py
+++ b/python/feature_repos/datastore/example.py
@@ -1,6 +1,7 @@
-from google.protobuf.duration_pb2 import Duration
+import datetime
 
-from feast import Entity, Feature, FeatureView, FileSource, ValueType, FeatureService
+from feast import Entity, Field, FeatureView, FileSource, FeatureService, ValueType
+from feast.types import Int64
 
 generated_data_source = FileSource(
     path="../../../generated_data.parquet",
@@ -15,14 +16,14 @@ entity = Entity(
 feature_views = [
     FeatureView(
         name=f"feature_view_{i}",
-        entities=["entity"],
-        ttl=Duration(seconds=86400),
-        features=[
-            Feature(name=f"feature_{10 * i + j}", dtype=ValueType.INT64)
+        entities=[entity],
+        ttl=datetime.timedelta(days=1),
+        schema=[
+            Field(name=f"feature_{10 * i + j}", dtype=Int64)
             for j in range(10)
         ],
         online=True,
-        batch_source=generated_data_source,
+        source=generated_data_source,
     )
     for i in range(25)
 ]

--- a/python/feature_repos/datastore/feature_store.yaml
+++ b/python/feature_repos/datastore/feature_store.yaml
@@ -5,6 +5,4 @@ online_store:
   type: datastore
 offline_store:
   type: file
-flags:
-  alpha_features: true
-  python_feature_server: true
+entity_key_serialization_version: 2

--- a/python/feature_repos/dynamo/example.py
+++ b/python/feature_repos/dynamo/example.py
@@ -1,6 +1,7 @@
-from google.protobuf.duration_pb2 import Duration
+import datetime
 
-from feast import Entity, Feature, FeatureView, FileSource, ValueType, FeatureService
+from feast import Entity, Field, FeatureView, FileSource, FeatureService, ValueType
+from feast.types import Int64
 
 generated_data_source = FileSource(
     path="../../../generated_data.parquet",
@@ -15,14 +16,14 @@ entity = Entity(
 feature_views = [
     FeatureView(
         name=f"feature_view_{i}",
-        entities=["entity"],
-        ttl=Duration(seconds=86400),
-        features=[
-            Feature(name=f"feature_{10 * i + j}", dtype=ValueType.INT64)
+        entities=[entity],
+        ttl=datetime.timedelta(days=1),
+        schema=[
+            Field(name=f"feature_{10 * i + j}", dtype=Int64)
             for j in range(10)
         ],
         online=True,
-        batch_source=generated_data_source,
+        source=generated_data_source,
     )
     for i in range(25)
 ]

--- a/python/feature_repos/dynamo/feature_store.yaml
+++ b/python/feature_repos/dynamo/feature_store.yaml
@@ -6,3 +6,4 @@ online_store:
   region: us-west-2
 offline_store:
   type: file
+entity_key_serialization_version: 2

--- a/python/feature_repos/local/example.py
+++ b/python/feature_repos/local/example.py
@@ -1,0 +1,45 @@
+import datetime
+
+from feast import Entity, Field, FeatureView, FileSource, FeatureService, ValueType
+from feast.types import Int64
+
+generated_data_source = FileSource(
+    path="../../../generated_data.parquet",
+    event_timestamp_column="event_timestamp",
+)
+
+entity = Entity(
+    name="entity",
+    value_type=ValueType.INT64,
+)
+
+feature_views = [
+    FeatureView(
+        name=f"feature_view_{i}",
+        entities=[entity],
+        ttl=datetime.timedelta(days=1),
+        schema=[
+            Field(name=f"feature_{10 * i + j}", dtype=Int64)
+            for j in range(10)
+        ],
+        online=True,
+        source=generated_data_source,
+    )
+    for i in range(25)
+]
+
+feature_services = [
+    FeatureService(
+        name=f"feature_service_{i}",
+        features=feature_views[:5*(i + 1)],
+    )
+    for i in range(5)
+]
+
+def add_definitions_in_globals():
+    for i, fv in enumerate(feature_views):
+        globals()[f"feature_view_{i}"] = fv
+    for i, fs in enumerate(feature_services):
+        globals()[f"feature_service_{i}"] = fs
+
+add_definitions_in_globals()

--- a/python/feature_repos/local/feature_store.yaml
+++ b/python/feature_repos/local/feature_store.yaml
@@ -1,0 +1,7 @@
+registry: data/registry.db
+project: feature_repo
+provider: local
+online_store:
+  type: sqlite
+  path: data/online_store.db
+entity_key_serialization_version: 2

--- a/python/feature_repos/redis/example.py
+++ b/python/feature_repos/redis/example.py
@@ -1,5 +1,4 @@
 import datetime
-from google.protobuf.duration_pb2 import Duration
 
 from feast import Entity, Field, FeatureView, FileSource, FeatureService, ValueType
 from feast.types import Int64

--- a/python/feature_repos/redis/example.py
+++ b/python/feature_repos/redis/example.py
@@ -1,6 +1,8 @@
+import datetime
 from google.protobuf.duration_pb2 import Duration
 
-from feast import Entity, Feature, FeatureView, FileSource, ValueType, FeatureService
+from feast import Entity, Field, FeatureView, FileSource, FeatureService, ValueType
+from feast.types import Int64
 
 generated_data_source = FileSource(
     path="../../../generated_data.parquet",
@@ -15,14 +17,14 @@ entity = Entity(
 feature_views = [
     FeatureView(
         name=f"feature_view_{i}",
-        entities=["entity"],
-        ttl=Duration(seconds=86400),
-        features=[
-            Feature(name=f"feature_{10 * i + j}", dtype=ValueType.INT64)
+        entities=[entity],
+        ttl=datetime.timedelta(days=1),
+        schema=[
+            Field(name=f"feature_{10 * i + j}", dtype=Int64)
             for j in range(10)
         ],
         online=True,
-        batch_source=generated_data_source,
+        source=generated_data_source,
     )
     for i in range(25)
 ]

--- a/python/feature_repos/redis/feature_store.yaml
+++ b/python/feature_repos/redis/feature_store.yaml
@@ -7,3 +7,4 @@ online_store:
 offline_store:
   type: file
 go_feature_retrieval: True
+entity_key_serialization_version: 2


### PR DESCRIPTION
While reproducing the Python benchmarks and extending them to cover Cassandra and the "Astra DB" DBaaS (built on Cassandra), which leverage the recently-added Cassandra online store contrib plugin, I upgraded this benchmark repo in several respects:

- (of course) local-Cassandra and Astra DB, Docker and feature repo items;
- a reference purely-local feature repo;
- extended instructions to provision the test machines (in a separate readme);
- improved instructions on how to run the benchmarks;
- upgrade to cover Feast 0.26 (in feature repo Python syntax and Dockerfiles), the latest version as of now;

